### PR TITLE
Add timestamp to screenshot name

### DIFF
--- a/src/screenshots/screenshot_exporter.ts
+++ b/src/screenshots/screenshot_exporter.ts
@@ -392,7 +392,7 @@ export function initHUDScreenshotExporter(mod: Mod) {
             logger.log("Exporting ...");
             const image = canvas.toDataURL("image/png");
             const link = document.createElement("a");
-            const timestamp = new Date().toISOString().replace('T', '_').replace(/:/g, '-').replace(/\..+/, '');
+            const timestamp = new Date().toLocaleString('sv').replace(/:/g, '-').replace(' ', '_');
             link.download = `base_${timestamp}.png`;
             link.href = image;
             link.click();

--- a/src/screenshots/screenshot_exporter.ts
+++ b/src/screenshots/screenshot_exporter.ts
@@ -392,7 +392,8 @@ export function initHUDScreenshotExporter(mod: Mod) {
             logger.log("Exporting ...");
             const image = canvas.toDataURL("image/png");
             const link = document.createElement("a");
-            link.download = "base.png";
+            const timestamp = new Date().toISOString().replace('T', '_').replace(/:/g, '-').replace(/\..+/, '');
+            link.download = `base_${timestamp}.png`;
             link.href = image;
             link.click();
             logger.log("Done!");


### PR DESCRIPTION
I take a lot of screenshots and sometimes it's a bit annoying to give them a name manually. This PR adds the current date and time to the suggested name when saving a screenshot. Example: `base_2023-05-10_21-40-50.png`